### PR TITLE
Added qt_toolbox_toolboxbutton to blacklisted widgets

### DIFF
--- a/ressources/pytsonui.py
+++ b/ressources/pytsonui.py
@@ -148,7 +148,7 @@ def retrieveAllWidgets(obj, parent, seticons=True, iconpack=None):
             _ts3print("Error loading iconpack: %s" % e, ts3defines.LogLevel.LogLevel_ERROR, "pytsonui.retrieveAllWidgets.%s" % obj.objectName, 0)
 
     for c in parent.children():
-        if c.isWidgetType() and c.objectName != "" and type(c) not in [QSplitterHandle] and c.objectName not in ["qt_scrollarea_viewport", "qt_scrollarea_hcontainer", "qt_scrollarea_vcontainer", "qt_spinbox_lineedit"]:
+        if c.isWidgetType() and c.objectName != "" and type(c) not in [QSplitterHandle] and c.objectName not in ["qt_scrollarea_viewport", "qt_scrollarea_hcontainer", "qt_scrollarea_vcontainer", "qt_spinbox_lineedit", "qt_toolbox_toolboxbutton"]:
             if hasattr(obj, c.objectName):
                 raise Exception("Widget objectName %s is not unique %s" % (c.objectName, type(c)))
             setattr(obj, c.objectName, c)


### PR DESCRIPTION
``` 2/28/2017 00:00:58	pyTSon.PluginHost.onMenuItemEvent	Error	Error calling onMenuItemEvent of python plugin Developer Tools: Traceback (most recent call last):
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/include\pluginhost.py", line 451, in onMenuItemEvent
    plugin.onMenuItemEvent(schid, atype, locid, selectedItemID)
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/scripts\devTools\__init__.py", line 378, in onMenuItemEvent
    self.tdlg = TestDialog(self)
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/scripts\devTools\__init__.py", line 216, in __init__
    setupUi(self, os.path.join(ts3.getPluginPath(), "pyTSon", "scripts", "devTools", "test.ui"))
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/include\pytsonui.py", line 207, in setupUi
    retrieveAllWidgets(obj, ui, seticons, iconpack)
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/include\pytsonui.py", line 159, in retrieveAllWidgets
    retrieveAllWidgets(obj, c, seticons, iconpack)
  File "C:/Users/blusc/AppData/Roaming/TS3Client/plugins/pyTSon/include\pytsonui.py", line 153, in retrieveAllWidgets
    raise Exception("Widget objectName %s is not unique %s" % (c.objectName, type(c)))
Exception: Widget objectName qt_toolbox_toolboxbutton is not unique <class 'PythonQt.private.QToolBoxButton'>```