### PR TITLE
ignore infoData completely if it returns none

### DIFF
--- a/ressources/python/pluginhost.py
+++ b/ressources/python/pluginhost.py
@@ -461,11 +461,11 @@ class PluginHost(pytson.Translatable):
         for key, p in cls.active.items():
             if p.infoTitle is not None and hasattr(p, "infoData"):
                 try:
-                    infoData = p.infoData(schid, aid, atype)
-                    if infoData is not None:
+                    data = p.infoData(schid, aid, atype)
+                    if data is not None:
                         if p.infoTitle != "":
                         ret.append(p.infoTitle)
-                        ret += p.infoData(schid, aid, atype)
+                        ret += data
                 except:
                     logprint(cls._tr("Error calling infoData of python plugin "
                                      "{name}: {trace}").format(

--- a/ressources/python/pluginhost.py
+++ b/ressources/python/pluginhost.py
@@ -461,9 +461,11 @@ class PluginHost(pytson.Translatable):
         for key, p in cls.active.items():
             if p.infoTitle is not None and hasattr(p, "infoData"):
                 try:
-                    if p.infoTitle != "":
+                    infoData = p.infoData(schid, aid, atype)
+                    if infoData is not None:
+                        if p.infoTitle != "":
                         ret.append(p.infoTitle)
-                    ret += p.infoData(schid, aid, atype)
+                        ret += p.infoData(schid, aid, atype)
                 except:
                     logprint(cls._tr("Error calling infoData of python plugin "
                                      "{name}: {trace}").format(

--- a/ressources/python/pluginhost.py
+++ b/ressources/python/pluginhost.py
@@ -464,8 +464,8 @@ class PluginHost(pytson.Translatable):
                     data = p.infoData(schid, aid, atype)
                     if data is not None:
                         if p.infoTitle != "":
-                        ret.append(p.infoTitle)
-                        ret += data
+                            ret.append(p.infoTitle)
+                            ret += data
                 except:
                     logprint(cls._tr("Error calling infoData of python plugin "
                                      "{name}: {trace}").format(


### PR DESCRIPTION
Good for scripts that only need infoData for a specific atype.